### PR TITLE
Removing session.connect method call of the OutboundSession constructor

### DIFF
--- a/examples/outbound_socket_example.py
+++ b/examples/outbound_socket_example.py
@@ -38,6 +38,7 @@ class MyApplication(object):
         """
         Main function that is called when a call comes in.
         """
+        self.session.connect()
         self.session.myevents()
         print("myevents")
         self.session.linger()

--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -87,6 +87,7 @@ class ESLProtocol(object):
                 if self.connected:
                     logging.error("Error receiving data, is FreeSWITCH running?")
                     self.connected = False
+                    self._run = False
                 break
             # Empty line
             if data == self._EOL:
@@ -256,7 +257,6 @@ class OutboundSession(ESLProtocol):
         self.connected = True
         self.session_data = None
         self.start_event_handlers()
-        self.connect()
         self.register_handle('*', self.on_event)
         self.register_handle('CHANNEL_HANGUP', self.on_hangup)
         self.expected_events = {}
@@ -463,6 +463,7 @@ class OutboundESLServer(object):
             self.handle_call(session)
 
         logging.info('Closing socket connection...')
+        self.server.shutdown(socket.SHUT_RD)
         self.server.close()
 
         logging.info('Waiting for calls to be ended. Currently, there are %s active calls' % self.connection_count)


### PR DESCRIPTION
If the socket receive an empty packet the socket will be disconnected,
because of this, is needed to call the connect method when receiving
a call.