### PR TITLE
Adding two dunders to work with context management.

### DIFF
--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -257,8 +257,7 @@ class InboundESL(ESLProtocol):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.send('exit')
-        self.connected = False
+        self.stop()
 
 class OutboundSession(ESLProtocol):
     def __init__(self, client_address, sock):

--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -252,6 +252,13 @@ class InboundESL(ESLProtocol):
         if response.headers['Reply-Text'] != '+OK accepted':
             raise ValueError('Invalid password.')
 
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.send('exit')
+        self.connected = False
 
 class OutboundSession(ESLProtocol):
     def __init__(self, client_address, sock):


### PR DESCRIPTION
When working with the library in the current way, if you instantiate many connections in a simutaneous way, there is no clear way to knock it down after you no longer need to maintain it.
Adding the __enter__ and __exit__ dunders, it is possible to work with and only keep the active connection within the required code block.