### PR TITLE
Implementation of Mapping protocol for ESLEvent

### DIFF
--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 import errno
 import logging
 import pprint
 import sys
+try: from collections.abc import Mapping
+except: from collections import Mapping
 
 import gevent
 import gevent.socket as socket
@@ -21,10 +22,38 @@ class OutboundSessionHasGoneAway(Exception):
     pass
 
 
-class ESLEvent(object):
+class ESLEvent(Mapping):
     def __init__(self, data):
         self.headers = {}
         self.parse_data(data)
+
+    def __getitem__(self, key):
+        return self.headers[key]
+
+    def __iter__(self):
+        return iter(self.headers)
+
+    def __len__(self):
+        return len(self.headers)
+
+    def keys(self):
+        return self.headers.keys()
+
+    def items(self):
+        return self.headers.items()
+
+    def values(self):
+        return self.headers.values()
+
+    def get(self, key, value=None):
+        return self.headers.get(key, value)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.headers == other.headers
+
+        else:
+            return NotImplemented
 
     def parse_data(self, data):
         data = unquote(data)


### PR DESCRIPTION
The implementation of the Mapping protocol for ESLEvent may seem like a sugar code, but it can make it easier to handle events when working with a handler.

The implemented methods serve only as interface for accessing self.headers, so this change does not imply any backward compatibility.

Example of use:

```python
>>> import greenswitch
>>> fs = greenswitch.InboundESL(host='127.0.0.1', port=8021, password='ClueCon')
>>> fs.connect()
>>> r = fs.send('api list_users')
>>> print r.data
>>> r.headers
{'Content-Type': 'api/response', 'Content-Length': '103'}
>>> r['Content-Type']
'api/response'
>>> r.data
'userid|context|domain|group|contact|callgroup|effective_caller_id_name|effective_caller_id_number\n\n+OK\n'
```

I believe that this adaptation makes the code more pytonic, because if the object behaves like a mapping and is used as a mapping, then it must be a mapping.