### PR TITLE
full coverage of ESLProtocol and some test utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ var/
 .pytest_cache/*
 .tags*
 .vscode/
+
+# pytest coverage plugin
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,7 @@ init:
 	pip install -r test_requirements.txt
 
 test:
-	pytest --spec -s tests
+	pytest --spec -s tests/
+
+test-coverage:
+	pytest --spec -s tests/ --cov=./greenswitch --cov-report term-missing

--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -55,10 +55,6 @@ class ESLProtocol(object):
         self._lingering = False
         self.connected = False
 
-    @property
-    def run(self):
-        return self._run
-
     def start_event_handlers(self):
         self._receive_events_greenlet = gevent.spawn(self.receive_events)
         self._process_events_greenlet = gevent.spawn(self.process_events)
@@ -166,7 +162,7 @@ class ESLProtocol(object):
 
     def process_events(self):
         logging.debug('Event Processor Running')
-        while self.run:
+        while self._run:
             if not self._process_esl_event_queue:
                 gevent.sleep(1)
                 continue

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-profiling
 pytest-spec
+pytest-cov

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-profiling
 pytest-spec
 pytest-cov
+mock

--- a/tests/test_lib_esl.py
+++ b/tests/test_lib_esl.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from textwrap import dedent
 import types
 

--- a/tests/test_lib_esl.py
+++ b/tests/test_lib_esl.py
@@ -474,7 +474,7 @@ class ESLProtocolTest(TestInboundESLBase):
         self.assertTrue(bad_handler.called)
         bad_handler.assert_called_with(event)
 
-    @mock.patch('greenswitch.esl.ESLProtocol.run', new_callable=mock.PropertyMock)
+    @mock.patch('greenswitch.esl.ESLProtocol._run', create=True, new_callable=mock.PropertyMock)
     @mock.patch('gevent.sleep')
     def test_process_events_quick_sleep_for_falsy_events_queue(self,
                                                                gevent_sleep,
@@ -482,24 +482,22 @@ class ESLProtocolTest(TestInboundESLBase):
         """
         `process_events` sleeps for 1s if ESL queue has falsy value.
         """
-        private_run_property.side_effect = [True, False]
-
         protocol = esl.ESLProtocol()
+        private_run_property.side_effect = [True, False]
         protocol._process_esl_event_queue = False
 
         protocol.process_events()
         self.assertTrue(gevent_sleep.called)
         gevent_sleep.assert_called_with(1)
 
-    @mock.patch('greenswitch.esl.ESLProtocol.run', new_callable=mock.PropertyMock)
+    @mock.patch('greenswitch.esl.ESLProtocol._run', create=True, new_callable=mock.PropertyMock)
     def test_process_events_with_custom_name(self, private_run_property):
         """
         `process_events` will accept an event with "Event-Name" header as "CUSTOM"
         in its headers by calling the handlers indexed by its "Event-Subclass".
         """
-        private_run_property.side_effect = [True, False]
-
         protocol = esl.ESLProtocol()
+        private_run_property.side_effect = [True, False]
         handlers = [mock.Mock(), mock.Mock()]
         protocol.event_handlers['custom-subclass'] = handlers
 
@@ -516,15 +514,14 @@ class ESLProtocolTest(TestInboundESLBase):
         self.assertTrue(handlers[1].called)
         handlers[1].assert_called_with(event)
 
-    @mock.patch('greenswitch.esl.ESLProtocol.run', new_callable=mock.PropertyMock)
+    @mock.patch('greenswitch.esl.ESLProtocol._run', create=True, new_callable=mock.PropertyMock)
     def test_process_events_with_log_type(self, private_run_property):
         """
         `process_events` will accept an event with "log/data" type
         and pass it to its handlers.
         """
-        private_run_property.side_effect = [True, False]
-
         protocol = esl.ESLProtocol()
+        private_run_property.side_effect = [True, False]
         handlers = [mock.Mock(), mock.Mock()]
         protocol.event_handlers['log'] = handlers
 
@@ -540,15 +537,14 @@ class ESLProtocolTest(TestInboundESLBase):
         self.assertTrue(handlers[1].called)
         handlers[1].assert_called_with(event)
 
-    @mock.patch('greenswitch.esl.ESLProtocol.run', new_callable=mock.PropertyMock)
+    @mock.patch('greenswitch.esl.ESLProtocol._run', create=True, new_callable=mock.PropertyMock)
     def test_process_events_with_no_handlers_will_rely_on_generic(self, private_run_property):
         """
         `process_events` will rely only on handlers for "*" if
         a given event has no handlers.
         """
-        private_run_property.side_effect = [True, False]
-
         protocol = esl.ESLProtocol()
+        private_run_property.side_effect = [True, False]
         fallback_handlers = [mock.Mock(), mock.Mock()]
         protocol.event_handlers['*'] = fallback_handlers
         other_handlers = [mock.Mock(), mock.Mock()]
@@ -569,16 +565,15 @@ class ESLProtocolTest(TestInboundESLBase):
         self.assertFalse(other_handlers[0].called)
         self.assertFalse(other_handlers[1].called)
 
-    @mock.patch('greenswitch.esl.ESLProtocol.run', new_callable=mock.PropertyMock)
+    @mock.patch('greenswitch.esl.ESLProtocol._run', create=True, new_callable=mock.PropertyMock)
     def test_process_events_with_pre_handler(self, private_run_property):
         """
         `process_events` will call for `before_handle` property
         if it was implemented on such protocol instance, but the
         event will also be passed to default handlers.
         """
-        private_run_property.side_effect = [True, False]
-
         protocol = esl.ESLProtocol()
+        private_run_property.side_effect = [True, False]
         protocol.before_handle = mock.Mock()
         some_handlers = [mock.Mock(), mock.Mock()]
         protocol.event_handlers['some-handlers'] = some_handlers
@@ -598,16 +593,15 @@ class ESLProtocolTest(TestInboundESLBase):
         self.assertTrue(some_handlers[1].called)
         some_handlers[1].assert_called_with(event)
 
-    @mock.patch('greenswitch.esl.ESLProtocol.run', new_callable=mock.PropertyMock)
+    @mock.patch('greenswitch.esl.ESLProtocol._run', create=True, new_callable=mock.PropertyMock)
     def test_process_events_with_post_handler(self, private_run_property):
         """
         `process_events` will call for `after_handle` property
         if it was implemented on such protocol instance, but the
         event will also be passed to default handlers.
         """
-        private_run_property.side_effect = [True, False]
-
         protocol = esl.ESLProtocol()
+        private_run_property.side_effect = [True, False]
         protocol.after_handle = mock.Mock()
         some_handlers = [mock.Mock(), mock.Mock()]
         protocol.event_handlers['some-handlers'] = some_handlers


### PR DESCRIPTION
it's a challenge to implement new features or add fixes if we can't trust not having breaking changes, so while studying the lib I tried to help by adding full unit coverage of `ESLProtocoL` class.

before:
![greenswitch-cov-before](https://user-images.githubusercontent.com/6237270/67029909-a0a6b380-f0e4-11e9-848a-fedb385bee69.png)

now:
![Screenshot from 2019-10-17 13-49-07](https://user-images.githubusercontent.com/6237270/67030028-e9f70300-f0e4-11e9-8b4c-62c41be1b2f4.png)

I made some other changes too: 
- ~wrapped `_run` property to make it more testable~
- added some blank lines for readability
- a recipe for test-coverage on makefile and test_requirements
- "polyfill" for mocks retrocompatible with python2

hope it helps. :)
