### PR TITLE
Remove strip to avoid issue when the final header is blank.

### DIFF
--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -29,7 +29,7 @@ class ESLEvent(object):
 
     def parse_data(self, data):
         data = unquote(data)
-        data = data.strip().splitlines()
+        data = data.splitlines()
         last_key = None
         value = ''
         for line in data:


### PR DESCRIPTION
Refer issue #67, fixing events with a blank final header and whitespace stripping in ESLEvent.parse_data().
