### PR TITLE
Fix error when stop() is called on certain conditions

### DIFF
--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -216,10 +216,12 @@ class ESLProtocol(object):
             except (NotConnectedError, socket.error):
                 pass
         self._run = False
-        logging.info("Waiting for receive greenlet exit")
-        self._receive_events_greenlet.join()
-        logging.info("Waiting for event processing greenlet exit")
-        self._process_events_greenlet.join()
+        if self._receive_events_greenlet:
+            logging.info("Waiting for receive greenlet exit")
+            self._receive_events_greenlet.join()
+        if self._process_events_greenlet:
+            logging.info("Waiting for event processing greenlet exit")
+            self._process_events_greenlet.join()
         self.sock.close()
         self.sock_file.close()
 


### PR DESCRIPTION
Fixes:
  AttributeError: "'NoneType' object has no attribute 'join'"

when calling stop and not authenticated (invalid password)