### PR TITLE
configurable timeout for InboundESL

### DIFF
--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -227,12 +227,12 @@ class ESLProtocol(object):
 
 
 class InboundESL(ESLProtocol):
-    def __init__(self, host, port, password):
+    def __init__(self, host, port, password, timeout=5):
         super(InboundESL, self).__init__()
         self.host = host
         self.port = port
         self.password = password
-        self.timeout = 5
+        self.timeout = timeout
         self.connected = False
 
     def connect(self):


### PR DESCRIPTION
For some reason (system spec or latency), that we need the timeout of InboundESL is not just 5 seconds.
This PR does not change the default behaviour, only effect when timeout value is defined.