### PR TITLE
Bugfix/logevent parsing no strip

### DIFF
--- a/greenswitch/esl.py
+++ b/greenswitch/esl.py
@@ -29,7 +29,7 @@ class ESLEvent(object):
 
     def parse_data(self, data):
         data = unquote(data)
-        data = data.strip().splitlines()
+        data = data.splitlines()
         last_key = None
         value = ''
         for line in data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def outbound_session(request):
 
 @pytest.fixture(scope="function")
 def disconnect_event(request):
-    event_plain = """
+    event_plain = """\
         Content-Type: text/disconnect-notice
         Controlled-Session-UUID: e4c3f7e0-bcc1-11ea-a87f-a5a0acaa832c
         Content-Disposition: disconnect


### PR DESCRIPTION
Refer issue #67, fixing events with a blank final header and whitespace stripping in ESLEvent.parse_data().

This is an updated pull request from earlier, rebased on current master with fixed and added tests. 
